### PR TITLE
Add a way to only reinitialize UrlRouterProvider rules

### DIFF
--- a/src/urlRouter.js
+++ b/src/urlRouter.js
@@ -18,9 +18,17 @@ $UrlRouterProvider.$inject = ['$locationProvider', '$urlMatcherFactoryProvider']
 function $UrlRouterProvider(   $locationProvider,   $urlMatcherFactory) {
   var rules = [], otherwise = null, interceptDeferred = false, listener;
 
-  this.init = function () {
+  this.init = function() {
+    this.initRules();
+    this.initOtherwise();
+  };
+
+  this.initRules = function() {
     rules = [];
-    otherwise = null;
+  };
+
+  this.initOtherwise = function() {
+    this.otherwise = null;
   };
 
   // Returns a string that is a prefix of all strings matching the RegExp


### PR DESCRIPTION
Dans notre cas, on ne doit pas réinitialiser le `otherwise` puisque `futureStates` s'en sert! J'ai donc gardé des façons de réinitialiser individuellement chaque composant.
